### PR TITLE
login success now sends userid that's stored in localstorage of browser

### DIFF
--- a/backend/api_server/user_auth_api/views.py
+++ b/backend/api_server/user_auth_api/views.py
@@ -39,7 +39,7 @@ class UserLogin(APIView):
 		if serializer.is_valid(raise_exception=True):
 			user = serializer.check_user(data)
 			login(request, user)
-			return Response(serializer.data, status=status.HTTP_200_OK)
+			return Response({"id": user.pk}, status=status.HTTP_200_OK)
 
 
 class UserLogout(APIView):

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -49,7 +49,10 @@ export default function Login() {
     } catch (error) {}
 
     if (resp?.data) {
+      const id = resp.data?.id;
       const csrf = Cookies.get('csrftoken')
+      
+      localStorage.setItem('USER_ID', id);
       localStorage.setItem('CSRF_TOKEN', csrf);
       navigate('/');
     } else {


### PR DESCRIPTION
- Sending userid on successful login rather than user email and password
- The user id is then stored in the browser's local storage
- can be used till the csrf issue is not resolved